### PR TITLE
ft(backend):  Enable comments on requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3450,6 +3450,7 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3466,6 +3467,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }

--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -1,0 +1,55 @@
+import Response from '../utils/response';
+import CommentService from '../services/commentService';
+
+const { createComment, getComment, deleteComment } = CommentService;
+const { success, badRequest } = Response;
+
+/**
+ * Controller form request comments
+ */
+export default class CommentController {
+/**
+ * @param {object} req - request object
+ * @param {object} res - response object
+ * @return {object} user - return object containing status and data
+ */
+  static async postComment(req, res) {
+    try {
+      const data = await createComment(req);
+
+      success(res, data, 201);
+    } catch ({ message: error }) {
+      badRequest(res, error);
+    }
+  }
+
+  /**
+ * @param {object} req - request object
+ * @param {object} res - response object
+ * @returns {object} user - return object containing status and data
+ */
+  static async getComment(req, res) {
+    try {
+      const data = await getComment(req);
+
+      success(res, data);
+    } catch ({ message: error }) {
+      badRequest(res, error);
+    }
+  }
+
+  /**
+ * @param {object} req - request object
+ * @param {object} res - response object
+ * @returns {object} user - return object containing status and data
+ */
+  static async deleteComment(req, res) {
+    try {
+      const data = await deleteComment(req);
+
+      success(res, data);
+    } catch ({ message: error }) {
+      badRequest(res, error);
+    }
+  }
+}

--- a/src/database/migrations/20190904163618-create-comment.js
+++ b/src/database/migrations/20190904163618-create-comment.js
@@ -1,0 +1,42 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Comments', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    comment: {
+      type: Sequelize.STRING
+    },
+    date: {
+      type: Sequelize.DATEONLY,
+      allowNull: false,
+      defaultValue: Sequelize.fn('now')
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'userId'
+      },
+      allowNull: false
+    },
+    requestId: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Requests',
+        key: 'id',
+        as: 'requestId'
+      },
+      allowNull: false
+    },
+    deleted: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    }
+  }, { timestamps: false }),
+  down: (queryInterface) => queryInterface.dropTable('Comments')
+};

--- a/src/database/seeders/20190828170224-demo-user.js
+++ b/src/database/seeders/20190828170224-demo-user.js
@@ -40,6 +40,16 @@ module.exports = {
     createdAt: new Date(),
     updatedAt: new Date()
   },
+  {
+    id: 5,
+    firstName: 'demo',
+    lastName: 'user',
+    email: 'demo2@mail.com',
+    password: '$2b$10$Ei9AIY7iUCU3jN3EAH7a8ez9lBmfazkBOHCI8SPbwWkD7iT4LWkYm',
+    roleId: 5,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
   ], {}),
 
   down: (queryInterface, Sequelize) => queryInterface.bulkDelete('Users', null, {})

--- a/src/database/seeders/20190906184427-demo-userdepartment.js
+++ b/src/database/seeders/20190906184427-demo-userdepartment.js
@@ -6,7 +6,19 @@ module.exports = {
     updatedAt: new Date()
   },
   {
+    userId: 5,
+    departmentId: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
     userId: 2,
+    departmentId: 2,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    userId: 4,
     departmentId: 2,
     createdAt: new Date(),
     updatedAt: new Date()

--- a/src/docs/docs.yaml
+++ b/src/docs/docs.yaml
@@ -744,8 +744,78 @@ paths:
         403:
           description: Authentication failed
       security:
+        - api_key: []  
+  /requests/{requestId}/comments:
+    post:
+      tags:
+        - Comments
+      summary: Creates a comment
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Comment body
+          required: true
+          schema:
+            type: object
+            properties:
+              comment:
+                type: string
+        - in: path
+          name: requestId
+          required: true
+          type: integer
+      responses:
+        400:
+          description: Error
+        201:
+          description: Success   
+      security:
+        - api_key: [] 
+    get: 
+      tags:
+        - Comments
+      summary: Gets all request comments
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: requestId
+          required: true
+          type: integer
+      responses:
+        400:
+          description: Error
+        200:
+          description: Success 
+      security:
         - api_key: []
-
+  /requests/{requestId}/comments/{commentId}:
+    delete:
+      tags:
+        - Comments
+      summary: Deletes a comment
+      produces:
+        - application/json
+      parameters:
+        - in: path
+          name: requestId
+          required: true
+          type: integer
+        - in: path
+          name: commentId
+          required: true
+          type: integer
+      responses:
+        400:
+          description: Error
+        200:
+          description: Success 
+      security:
+        - api_key: []
 definitions:
   AuthResponse:
     properties:

--- a/src/models/Comment.js
+++ b/src/models/Comment.js
@@ -1,0 +1,20 @@
+module.exports = (sequelize, DataTypes) => {
+  const Comment = sequelize.define('Comment', {
+    comment: DataTypes.STRING,
+    deleted: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    }
+  }, { timestamps: false });
+  Comment.associate = (models) => {
+    Comment.belongsTo(models.User, {
+      foreignKey: 'userId'
+    });
+
+    Comment.belongsTo(models.Request, {
+      foreignKey: 'requestId'
+    });
+  };
+  return Comment;
+};

--- a/src/models/Request.js
+++ b/src/models/Request.js
@@ -37,6 +37,9 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'userId',
       onDelete: 'CASCADE'
     });
+    Request.hasMany(models.Comment, {
+      foreignKey: 'requestId'
+    });
   };
   return Request;
 };

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -67,6 +67,9 @@ module.exports = (sequelize, DataTypes) => {
     User.hasOne(models.UserDepartment, {
       foreignKey: 'userId'
     });
+    User.hasMany(models.Comment, {
+      foreignKey: 'userId'
+    });
   };
   return User;
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,4 +7,5 @@ const router = Router();
 router.use('/auth', authRoute);
 router.use('/requests', requestRoute);
 
+
 export default router;

--- a/src/routes/request.js
+++ b/src/routes/request.js
@@ -1,9 +1,14 @@
 import { Router } from 'express';
-import { requestSchema, requestIdSchema, responseSchema } from '../validation/schemas';
+import {
+  requestSchema, requestIdSchema, responseSchema, commentSchema
+} from '../validation/schemas';
 import RequestController from '../controllers/requestController';
 import { validator } from '../validation/validator';
 import middlewares from '../middlewares';
+import commentController from '../controllers/commentController';
 
+
+const { postComment, getComment, deleteComment } = commentController;
 const router = Router();
 const { auth, permitUser } = middlewares;
 const {
@@ -27,5 +32,8 @@ router.get('/userRequests', auth, getRequests);
 router.post('/return', [auth, validator(requestSchema)], returnRequest);
 router.get('/search', auth, search);
 
+router.post('/:requestId/comments', [auth, validator(commentSchema)], postComment);
+router.get('/:requestId/comments', auth, getComment);
+router.delete('/:requestId/comments/:commentId', auth, deleteComment);
 
 export default router;

--- a/src/services/commentService.js
+++ b/src/services/commentService.js
@@ -1,0 +1,93 @@
+import db from '../models';
+import Response from '../utils/response';
+
+const { error } = Response;
+
+/**
+ * Comment Service class
+ */
+export default class CommentService {
+/**
+ * @param {string} comment user comment on request
+ * @param {integer} requestId request id
+ * @param {integer} userId user id
+ * @returns {void}
+ */
+  static async createComment({ body: { comment }, params: { requestId }, user: { id } }) {
+    const checkRequest = await db.Request.findOne({ where: { id: requestId } });
+
+    if (checkRequest === null) error('Request does not exist');
+
+    const { userId } = checkRequest;
+    const userDept = await db.UserDepartment.findOne({
+      include: [db.Department], where: { userId }
+    });
+    const { dataValues: { Department: { dataValues: { manager } } } } = userDept;
+
+    if (id !== manager && id !== userId)error('You cannot comment on this request');
+
+    const result = await db.Comment.create({ comment, requestId, userId: id });
+
+    return result;
+  }
+
+  /**
+   * @param {integer} requestId the request id
+   * @returns {void}
+   */
+  static async getComment({ params: { requestId }, user: { id } }) {
+    const checkRequest = await db.Request.findOne({ where: { id: requestId } });
+
+    if (checkRequest === null) error('Request does not exist');
+
+    const { userId } = checkRequest;
+    const userDept = await db.UserDepartment.findOne({
+      include: [db.Department], where: { userId }
+    });
+    const { dataValues: { Department: { dataValues: { manager } } } } = userDept;
+
+    if (id !== manager && id !== userId)error('You cannot see these comments');
+
+    const result = await db.Comment.findAll({
+      where: {
+        deleted: false, requestId
+      }
+    });
+
+    if (!result.length) error('The are no comments on this request');
+
+    return result;
+  }
+
+  /**
+   * @param {integer} userId user id
+   * @param {integer} commentId comment id
+   * @param {integer} requestId request id
+   * @returns {void}
+   */
+  static async deleteComment({ params: { commentId, requestId }, user: { id } }) {
+    const checkRequest = await db.Request.findOne({ where: { id: requestId } });
+
+    if (checkRequest === null) error('Request does not exist');
+
+    const checkComment = await db.Comment.findOne({ where: { id: commentId } });
+
+    if (checkComment === null) error('Comment does not exist');
+
+    const { userId, requestId: request } = checkComment;
+
+    if (userId !== id) error('This Comment is not yours');
+    if (request.toString() !== requestId) error('Incorrect request id');
+
+
+    await db.Comment.update({
+      deleted: true,
+    }, {
+      where: {
+        userId: id, id: commentId, requestId
+      }
+    });
+
+    return 'Comment deleted';
+  }
+}

--- a/src/tests/auth.test.js
+++ b/src/tests/auth.test.js
@@ -47,8 +47,8 @@ describe('/api/v1/auth', () => {
   });
 
   before(async () => {
-    await TestHelper.destroyModel('Request');
     await TestHelper.destroyModel('User');
+    await TestHelper.destroyModel('Request');
     await TestHelper.destroyModel('Role');
     await db.Role.bulkCreate(insertRoles);
     verifiedUser = await TestHelper.createUser({

--- a/src/tests/comments.test.js
+++ b/src/tests/comments.test.js
@@ -1,0 +1,217 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../index';
+import db from '../models';
+import TestHelper from '../utils/testHelper';
+import {
+  user1, user2, user3, commentBody, oneWayTrip, oneWayTrip2, userDepartments, departments
+} from './testData/sampleData';
+
+chai.use(chaiHttp);
+
+let authToken;
+let imposterToken;
+let imposterToken2;
+let commentId;
+let requestId;
+let badRequestId;
+const URL_PREFIX = '/api/v1/requests';
+
+describe('api/v1/requests/:requestId/comments', () => {
+  before(async () => {
+    await TestHelper.destroyModel('User');
+    await TestHelper.destroyModel('Request');
+    await TestHelper.destroyModel('Comment');
+    await TestHelper.destroyModel('Department');
+    await TestHelper.destroyModel('UserDepartment');
+
+    const { token } = await TestHelper.createUser({
+      ...user1, isVerified: true
+    });
+    const { token: token1 } = await TestHelper.createUser({
+      ...user2, isVerified: true
+    });
+    const { token: token2 } = await TestHelper.createUser({
+      ...user3, isVerified: true
+    });
+    const { body: { data: { id } } } = await chai.request(app)
+      .post(`${URL_PREFIX}/one-way`)
+      .set('token', token)
+      .send(oneWayTrip);
+    const { body: { data: { id: second } } } = await chai.request(app)
+      .post(`${URL_PREFIX}/one-way`)
+      .set('token', token)
+      .send(oneWayTrip2);
+
+    await db.Department.bulkCreate(departments);
+    await db.UserDepartment.bulkCreate(userDepartments);
+
+    authToken = token;
+    imposterToken = token1;
+    imposterToken2 = token2;
+    requestId = id;
+    badRequestId = second;
+  });
+
+  it('should return an error when there are no comments', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .get(`${URL_PREFIX}/${requestId}/comments`)
+      .set('token', authToken)
+      .send();
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('The are no comments on this request');
+  });
+
+  it('should create a comment with valid data', async () => {
+    const { body: { data: { comment, id } }, status } = await chai.request(app)
+      .post(`${URL_PREFIX}/${requestId}/comments`)
+      .set('token', authToken)
+      .send(commentBody);
+
+    commentId = id;
+    expect(status).to.equal(201);
+    expect(comment).to.equal('this is a comment');
+  });
+
+  it('should return an error when a non manager or user tries to comment', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .post(`${URL_PREFIX}/${requestId}/comments`)
+      .set('token', imposterToken2)
+      .send(commentBody);
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('You cannot comment on this request');
+  });
+
+  it('should return an error if request does not exist', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .post(`${URL_PREFIX}/10000/comments`)
+      .set('token', authToken)
+      .send(commentBody);
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('Request does not exist');
+  });
+
+  it('should return an error  with invalid data', async () => {
+    const { body: { error: [first] }, status } = await chai.request(app)
+      .post(`${URL_PREFIX}/${requestId}/comments`)
+      .set('token', authToken)
+      .send('commentBody');
+
+    expect(status).to.equal(400);
+    expect(first).to.equal('Comment is required');
+  });
+
+  it('should return an error message for invalid request id', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .post(`${URL_PREFIX}/requestId/comments`)
+      .set('token', authToken)
+      .send(commentBody);
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('invalid input syntax for integer: "requestId"');
+  });
+
+  it('should return an error when a non manager or user tries to view comment', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .get(`${URL_PREFIX}/${requestId}/comments`)
+      .set('token', imposterToken2)
+      .send();
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('You cannot see these comments');
+  });
+
+  it('should get requests comments', async () => {
+    const { body: { data: [first] }, status } = await chai.request(app)
+      .get(`${URL_PREFIX}/${requestId}/comments`)
+      .set('token', authToken)
+      .send();
+    const { comment } = first;
+
+    expect(status).to.equal(200);
+    expect(comment).to.equal('this is a comment');
+  });
+
+  it('should return an error message if request does not exist', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .get(`${URL_PREFIX}/1000/comments`)
+      .set('token', authToken)
+      .send();
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('Request does not exist');
+  });
+
+  it('should throw an error for invalid request id', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .get(`${URL_PREFIX}/requestId/comments`)
+      .set('token', authToken)
+      .send();
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('invalid input syntax for integer: "requestId"');
+  });
+
+  it('should update the deleted field', async () => {
+    const { body: { data }, status } = await chai.request(app)
+      .delete(`${URL_PREFIX}/${requestId}/comments/${commentId}`)
+      .set('token', authToken)
+      .send();
+
+    expect(status).to.equal(200);
+    expect(data).to.equal('Comment deleted');
+  });
+
+  it('should throw an error for an incorrect request id', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .delete(`${URL_PREFIX}/${badRequestId}/comments/${commentId}`)
+      .set('token', authToken)
+      .send();
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('Incorrect request id');
+  });
+
+  it('should throw an error for wrong', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .delete(`${URL_PREFIX}/${requestId}/comments/${commentId}`)
+      .set('token', imposterToken)
+      .send();
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('This Comment is not yours');
+  });
+
+  it('should return an error when attempting to delete with an invalid comment id', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .delete(`${URL_PREFIX}/${requestId}/comments/commentId`)
+      .set('token', authToken)
+      .send();
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('invalid input syntax for integer: "commentId"');
+  });
+
+  it('should return an error when attempting to delete a comment with the wrong id', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .delete(`${URL_PREFIX}/10000/comments/${commentId}`)
+      .set('token', authToken)
+      .send();
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('Request does not exist');
+  });
+
+  it('should return an error when attempting to delete comment that does not exist', async () => {
+    const { body: { error }, status } = await chai.request(app)
+      .delete(`${URL_PREFIX}/${requestId}/comments/666`)
+      .set('token', authToken)
+      .send();
+
+    expect(status).to.equal(400);
+    expect(error).to.equal('Comment does not exist');
+  });
+});

--- a/src/tests/passwordReset.test.js
+++ b/src/tests/passwordReset.test.js
@@ -24,6 +24,9 @@ describe('/api/v1/auth', () => {
   });
 
   before(async () => {
+    await TestHelper.destroyModel('Request');
+    await TestHelper.destroyModel('User');
+    await TestHelper.destroyModel('Role');
     await db.Role.bulkCreate(insertRoles);
     fakeToken = await Helper.genToken({ email: 'fake@chubi.com' });
     await db.User.create({

--- a/src/tests/testData/sampleData.js
+++ b/src/tests/testData/sampleData.js
@@ -48,6 +48,15 @@ export const oneWayTrip = {
   reason: 'reason',
   accommodation: 'accommodation'
 };
+export const oneWayTrip2 = {
+  source: 'Lagos',
+  tripType: 'one-way',
+  destination: 'Abuja',
+  travelDate: '10/02/2019',
+  returnDate: Date.now(),
+  reason: 'reason',
+  accommodation: 'accommodation'
+};
 
 export const testRequest = {
   source: 'Lagos',
@@ -82,4 +91,64 @@ export const returnRequest = {
   returnDate: '01/01/2018',
   reason: 'Work',
   accommodation: 'Radison Blu'
+};
+
+export const user1 = {
+  id: 1,
+  email: 'earl@ragner.com',
+  firstName: 'John',
+  lastName: 'lennon',
+  password: 'letmebe123'
+};
+
+export const user2 = {
+  id: 2,
+  email: 'earl@borg.com',
+  firstName: 'John',
+  lastName: 'lennon',
+  password: 'letmebe123'
+};
+
+export const user3 = {
+  id: 3,
+  email: 'earl@ingstad.com',
+  firstName: 'John',
+  lastName: 'lennon',
+  password: 'letmebe123'
+};
+
+export const userDepartments = [
+  {
+    userId: 1,
+    departmentId: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    userId: 2,
+    departmentId: 2,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+];
+
+export const departments = [
+  {
+    id: 1,
+    department: 'devOps',
+    manager: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    id: 2,
+    department: 'devOps',
+    manager: 2,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+];
+
+export const commentBody = {
+  comment: 'this is a comment'
 };

--- a/src/utils/testHelper.js
+++ b/src/utils/testHelper.js
@@ -30,6 +30,7 @@ export default class TestHelper {
     return { token, ...Helper.omitFields(result, ['password']) };
   }
 
+
   /**
    * Method to exclude properties from an object
    * @param {string} modelName - model to droped

--- a/src/validation/schemas.js
+++ b/src/validation/schemas.js
@@ -123,3 +123,10 @@ export const requestSchema = Joi.object().keys({
   status: Joi.string(),
   accommodation: Joi.string().required().error(() => ({ message: 'Accommodation is required' }))
 });
+
+export const commentSchema = Joi.object().keys({
+  comment: Joi.string().trim().required()
+    .error(() => ({
+      message: 'Comment is required'
+    }))
+});


### PR DESCRIPTION
**What does this PR do?**
   Allows user to comment on trip requests by carrying out CRUD operations on comments model

  **Description of Task to be completed?**
  - Creates a comments model
  - Creates routes for creating, getting and updating comments to requests
  - Updates swagger documentation
  -  Creates additional tests in test suite

  **How should this be manually tested?**
  - Fetch and checkout into this branch.
  - Run 'npm I' on your terminal.
  - Startup the server.
  -  navigate to postman.
  -  Sign up and create a request(using the request id as requestId in the route below) 
  -  Send a post request on the following route 'localhost:3000/api/v1/requests/{requestId}comments', providing a comments field on the body.
  - Send a get request on the same route above.
  -  Send a delete request on the following route  'localhost:3000/api/v1/requests/{requestId}comments','localhost:3000/api/v1/requests/{requestId}comments/{commentId}', where commentId is the Id of the comment create earlier.

  **Any background context you want to provide?**

  

  **What are the relevant stories?**

  #### pivotal tracker stories
 - [create](https://www.pivotaltracker.com/n/projects/2382051/stories/167735051)
 - [delete](https://www.pivotaltracker.com/n/projects/2382051/stories/167734993)

  **Screenshots (if appropriate)**

  
![Screenshot from 2019-09-06 00-23-31](https://user-images.githubusercontent.com/50267237/64391406-76bb9500-d040-11e9-93c8-9a66c00a0adb.png)
![Screenshot from 2019-09-06 00-23-36](https://user-images.githubusercontent.com/50267237/64391410-7ae7b280-d040-11e9-919f-cd590f933c99.png)



  **Questions:**

 N/A
